### PR TITLE
Add `page_id` Support to Conversations and Page Context Awareness

### DIFF
--- a/backend/app/api/v1/endpoints/ai_providers.py
+++ b/backend/app/api/v1/endpoints/ai_providers.py
@@ -497,6 +497,7 @@ async def chat_completion(request: ChatCompletionRequest, db: AsyncSession = Dep
                     user_id=user_id,
                     title=f"Conversation with {request.model}",
                     page_context=request.page_context,  # This is already defined in the schema with a default of None
+                    page_id=request.page_id,  # NEW FIELD - ID of the page this conversation belongs to
                     model=request.model,
                     server=provider_instance.server_name,
                     conversation_type=request.conversation_type or "chat"  # New field with default

--- a/backend/app/api/v1/endpoints/conversations.py
+++ b/backend/app/api/v1/endpoints/conversations.py
@@ -30,6 +30,7 @@ async def get_user_conversations(
     limit: int = Query(20, ge=1, le=100),
     tag_id: Optional[str] = Query(None, description="Filter by tag ID"),
     conversation_type: Optional[str] = Query(None, description="Filter by conversation type"),
+    page_id: Optional[str] = Query(None, description="Filter by page ID"),
     db: AsyncSession = Depends(get_db),
     current_user = Depends(get_current_user)
 ):
@@ -47,6 +48,10 @@ async def get_user_conversations(
     from app.models.tag import ConversationTag
     
     query = select(Conversation).where(Conversation.user_id == formatted_user_id)
+    
+    # Filter by page_id if provided
+    if page_id:
+        query = query.where(Conversation.page_id == page_id)
     
     # Filter by tag if provided
     if tag_id:
@@ -97,6 +102,7 @@ async def create_conversation(
         user_id=conversation_user_id,  # Use formatted user ID
         title=conversation.title,
         page_context=conversation.page_context,
+        page_id=conversation.page_id,  # NEW FIELD
         model=conversation.model,
         server=conversation.server,
         conversation_type=conversation.conversation_type or "chat"  # New field with default
@@ -161,6 +167,8 @@ async def update_conversation(
         conversation.title = conversation_update.title
     if conversation_update.page_context is not None:
         conversation.page_context = conversation_update.page_context
+    if conversation_update.page_id is not None:
+        conversation.page_id = conversation_update.page_id
     if conversation_update.model is not None:
         conversation.model = conversation_update.model
     if conversation_update.server is not None:

--- a/backend/app/schemas/ai_providers.py
+++ b/backend/app/schemas/ai_providers.py
@@ -22,6 +22,9 @@ class TextGenerationRequest(BaseModel):
     user_id: Optional[str] = Field(None, description="User ID for access control")
     params: Dict[str, Any] = Field(default_factory=dict, description="Additional parameters")
     stream: bool = Field(False, description="Whether to stream the response")
+    page_id: Optional[str] = Field(None, description="ID of the page this generation belongs to")
+    page_context: Optional[str] = Field(None, description="Context of the page where this generation is happening")
+    conversation_type: Optional[str] = Field("chat", description="Type/category of the conversation")
 
 
 class ChatMessage(BaseModel):
@@ -41,6 +44,7 @@ class ChatCompletionRequest(BaseModel):
     params: Dict[str, Any] = Field(default_factory=dict, description="Additional parameters")
     stream: bool = Field(False, description="Whether to stream the response")
     conversation_id: Optional[str] = Field(None, description="ID of an existing conversation to continue")
+    page_id: Optional[str] = Field(None, description="ID of the page this conversation belongs to")
     page_context: Optional[str] = Field(None, description="Context where the conversation is taking place (e.g., 'home', 'editor', 'chatbot_lab')")
     conversation_type: Optional[str] = Field("chat", description="Type/category of the conversation (e.g., 'chat', 'email_reply', 'therapy')")
 

--- a/backend/app/schemas/conversation_schemas.py
+++ b/backend/app/schemas/conversation_schemas.py
@@ -33,6 +33,7 @@ class Message(MessageInDB):
 class ConversationBase(BaseModel):
     title: Optional[str] = Field(None, description="Title of the conversation")
     page_context: Optional[str] = Field(None, description="Context where the conversation was created")
+    page_id: Optional[str] = Field(None, description="ID of the page this conversation belongs to")
     model: Optional[str] = Field(None, description="LLM model used for the conversation")
     server: Optional[str] = Field(None, description="Server used for the conversation")
     conversation_type: Optional[str] = Field("chat", description="Type/category of the conversation (e.g., 'chat', 'email_reply', 'therapy')")

--- a/backend/migrations/versions/add_page_id_to_conversations.py
+++ b/backend/migrations/versions/add_page_id_to_conversations.py
@@ -1,0 +1,41 @@
+"""add page_id to conversations
+
+Revision ID: add_page_id_to_conversations
+Revises: add_conversation_type_simple
+Create Date: 2025-06-25 13:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = 'add_page_id_to_conversations'
+down_revision: Union[str, None] = 'add_conversation_type_simple'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Add page_id column to conversations table
+    # Using batch_alter_table for SQLite compatibility
+    with op.batch_alter_table('conversations', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('page_id', sa.String(length=32), nullable=True))
+    
+    # Add indexes for efficient querying (SQLite compatible)
+    op.create_index('idx_conversations_page_id', 'conversations', ['page_id'], unique=False)
+    op.create_index('idx_conversations_user_page', 'conversations', ['user_id', 'page_id'], unique=False)
+    
+    # Note: Existing conversations will have page_id = NULL (treated as global conversations)
+    # New page-specific conversations will have specific page_id values
+
+
+def downgrade() -> None:
+    # Remove indexes first
+    op.drop_index('idx_conversations_user_page', table_name='conversations')
+    op.drop_index('idx_conversations_page_id', table_name='conversations')
+    
+    # Remove page_id column using batch_alter_table for SQLite compatibility
+    with op.batch_alter_table('conversations', schema=None) as batch_op:
+        batch_op.drop_column('page_id')

--- a/backend/migrations/versions/c7eed881f009_merge_heads.py
+++ b/backend/migrations/versions/c7eed881f009_merge_heads.py
@@ -1,0 +1,26 @@
+"""merge heads
+
+Revision ID: c7eed881f009
+Revises: restore_settings_tables, add_page_id_to_conversations
+Create Date: 2025-06-25 13:34:43.475716
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'c7eed881f009'
+down_revision: Union[str, None] = ('restore_settings_tables', 'add_page_id_to_conversations')
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,6 +10,7 @@ import { SettingsService } from './services/SettingsService';
 import { UserSettingsInitService } from './services/UserSettingsInitService';
 import { userNavigationInitService } from './services/UserNavigationInitService';
 import { eventService } from './services/EventService';
+import { pageContextService } from './services/PageContextService';
 import { useAppTheme } from './hooks/useAppTheme';
 import { config } from './config';
 import { PluginManager } from './components/PluginManager';
@@ -38,6 +39,7 @@ serviceRegistry.registerService(settingsService);
 serviceRegistry.registerService(userSettingsInitService);
 serviceRegistry.registerService(userNavigationInitService);
 serviceRegistry.registerService(eventService);
+serviceRegistry.registerService(pageContextService);
 
 function AppContent() {
   const theme = useAppTheme();

--- a/frontend/src/components/DynamicPageRenderer.tsx
+++ b/frontend/src/components/DynamicPageRenderer.tsx
@@ -19,6 +19,7 @@ import { defaultPageService } from '../services/defaultPageService';
 import { PluginModuleRenderer } from './PluginModuleRenderer';
 import { PluginProvider } from '../contexts/PluginContext';
 import { getAvailablePlugins } from '../plugins';
+import { pageContextService } from '../services/PageContextService';
 
 interface DynamicPageRendererProps {
   pageId?: string;  // Optional: directly specify page ID
@@ -124,21 +125,32 @@ export const DynamicPageRenderer: React.FC<DynamicPageRendererProps> = ({ pageId
   // Memoize the current page ID to prevent unnecessary recalculations
   const currentId = useMemo(() => getPageId(), [pageId, route, location.pathname]);
 
-  // Update global variables when page or studio status changes
+  // Update global variables and page context when page or studio status changes
   useEffect(() => {
     if (page) {
       window.currentPageTitle = page.name;
       window.isStudioPage = isStudioPage;
 
+      // Update the page context service
+      const pageContextData = {
+        pageId: page.id || currentId,
+        pageName: page.name || 'Unknown Page',
+        pageRoute: page.route || location.pathname,
+        isStudioPage
+      };
+      
+      pageContextService.setPageContext(pageContextData);
+
       console.log('DynamicPageRenderer - Current path:', location.pathname);
       console.log('DynamicPageRenderer - Is studio page:', isStudioPage);
       console.log('DynamicPageRenderer - Page name:', page.name);
+      console.log('DynamicPageRenderer - Page context updated:', pageContextData);
       console.log('DynamicPageRenderer - Global variables:', {
         currentPageTitle: window.currentPageTitle,
         isStudioPage: window.isStudioPage
       });
     }
-  }, [page, isStudioPage, location.pathname]);
+  }, [page, currentId, isStudioPage, location.pathname]);
   
   // Function to handle module state changes
   const handleModuleStateChange = useCallback((moduleId: string, state: any) => {

--- a/frontend/src/services/PageContextService.ts
+++ b/frontend/src/services/PageContextService.ts
@@ -1,0 +1,80 @@
+import { AbstractBaseService } from './base/BaseService';
+
+export interface PageContextData {
+  pageId: string;
+  pageName: string;
+  pageRoute: string;
+  isStudioPage: boolean;
+}
+
+export interface PageContextServiceInterface {
+  getCurrentPageContext(): PageContextData | null;
+  onPageContextChange(callback: (context: PageContextData) => void): () => void;
+}
+
+class PageContextServiceImpl extends AbstractBaseService implements PageContextServiceInterface {
+  private currentContext: PageContextData | null = null;
+  private listeners: ((context: PageContextData) => void)[] = [];
+  private static instance: PageContextServiceImpl;
+
+  private constructor() {
+    super(
+      'pageContext',
+      { major: 1, minor: 0, patch: 0 },
+      [
+        {
+          name: 'page-context-management',
+          description: 'Page context tracking and management capabilities',
+          version: '1.0.0'
+        },
+        {
+          name: 'page-context-events',
+          description: 'Page context change event subscription system',
+          version: '1.0.0'
+        }
+      ]
+    );
+  }
+
+  public static getInstance(): PageContextServiceImpl {
+    if (!PageContextServiceImpl.instance) {
+      PageContextServiceImpl.instance = new PageContextServiceImpl();
+    }
+    return PageContextServiceImpl.instance;
+  }
+
+  async initialize(): Promise<void> {
+    // Initialize the service - no special initialization needed for now
+    console.log('[PageContextService] Initialized');
+  }
+
+  async destroy(): Promise<void> {
+    // Clean up listeners
+    this.listeners = [];
+    this.currentContext = null;
+    console.log('[PageContextService] Destroyed');
+  }
+
+  getCurrentPageContext(): PageContextData | null {
+    return this.currentContext;
+  }
+
+  setPageContext(context: PageContextData): void {
+    this.currentContext = context;
+    this.listeners.forEach(listener => listener(context));
+  }
+
+  onPageContextChange(callback: (context: PageContextData) => void): () => void {
+    this.listeners.push(callback);
+    
+    // Return unsubscribe function
+    return () => {
+      const index = this.listeners.indexOf(callback);
+      if (index > -1) {
+        this.listeners.splice(index, 1);
+      }
+    };
+  }
+}
+
+export const pageContextService = PageContextServiceImpl.getInstance();


### PR DESCRIPTION
# 🧩 Add `page_id` Support to Conversations and Page Context Awareness

## Overview

This PR introduces native support for associating conversations with specific pages via a new `page_id` field in the `conversations` table. It also enhances both backend and frontend APIs to allow filtering, creation, and tracking of conversations by page, enabling better scoping of AI interactions within multi-page applications.

Additionally, the frontend now includes a global Page Context Service for consistent awareness of the current page's metadata throughout the app.

---

## 🎯 Key Features

### Conversation Page Association

* ✅ New database field: `page_id` added to the `conversations` table
* ✅ API support for filtering conversations by `page_id`
* ✅ Support for passing `page_id` in `ChatCompletionRequest` and `TextGenerationRequest`
* ✅ Alembic migration included with indexing for performance

### Page Context Tracking (Frontend)

* ✅ Introduced `PageContextService` to maintain and propagate `pageId`, `pageName`, and `isStudioPage` flags
* ✅ `DynamicPageRenderer` now sets global page context when a page loads
* ✅ Backend-ready foundation for page-scoped analytics, behavior, and personalization

---

## 📁 Files Added

### Migrations

* [`[add_page_id_to_conversations.py](https://chatgpt.com/c/backend/migrations/versions/add_page_id_to_conversations.py)`](backend/migrations/versions/add_page_id_to_conversations.py) – Adds `page_id` column and indexes
* [`[c7eed881f009_merge_heads.py](https://chatgpt.com/c/backend/migrations/versions/c7eed881f009_merge_heads.py)`](backend/migrations/versions/c7eed881f009_merge_heads.py) – Merges concurrent migration branches

### Frontend Service

* [`[PageContextService.ts](https://chatgpt.com/c/frontend/src/services/PageContextService.ts)`](frontend/src/services/PageContextService.ts) – New service for managing and broadcasting page metadata context

---

## 📝 Files Modified

### Backend Models & API

* `models/conversation.py`

  * Added `page_id` column and related query methods:

    * `get_by_user_id_and_page()`
    * `count_by_user_and_page()`
* `endpoints/conversations.py`

  * Added support for filtering and setting `page_id` in `GET`, `POST`, and `PUT` operations
* `endpoints/ai_providers.py`

  * Accepts and stores `page_id` in `chat_completion`
* `schemas/ai_providers.py`

  * Updated `ChatCompletionRequest` and `TextGenerationRequest` schemas to include `page_id` and `page_context`
* `schemas/conversation_schemas.py`

  * Added `page_id` field to `ConversationBase`

### Frontend Application

* `App.tsx`

  * Registered `pageContextService` with the service registry
* `DynamicPageRenderer.tsx`

  * Sets page context based on resolved route
  * Logs updates and reflects `pageId` changes
* `PluginManager` and other plugins can now subscribe to page context globally

---

## 🔧 Configuration

No new environment variables or external configuration is required. The system works automatically once the frontend page is resolved.

---

## 🚀 Usage

### Creating Conversations Associated with a Page

```json
POST /api/v1/conversations
{
  "title": "Page-Specific Conversation",
  "page_id": "page_abc123",
  "model": "gpt-4",
  "conversation_type": "chat"
}
```

### Filtering by Page

```
GET /api/v1/conversations?page_id=page_abc123
```

---

## 🔄 Migration Strategy

```bash
alembic upgrade head
```

### Migration Details

* Adds nullable `page_id` column to `conversations`
* Adds indexes:

  * `conversations.page_id`
  * `conversations.user_id + page_id`
* Existing conversations default to `page_id = NULL` (global scope)

---

## 🎯 Impact

### Developer Benefits

* Backend support for scoped conversations per page
* Enables modular dashboards with local chat history
* Simplifies tracking conversation flow and context per page

### Frontend Benefits

* Global `PageContextService` opens cross-component awareness of current page identity and behavior
* Foundation for per-page plugin behavior, analytics, or access control

---

## ⚠️ Important Notes

* This is a non-breaking schema expansion
* Migration is forward-only but safe
* Frontend plugin developers can now access current page ID and route from anywhere using `pageContextService.getCurrentPageContext()`

---

## 🔗 Related Use Cases

* Personal chat history per app section or workspace
* AI responses scoped to a specific studio, dashboard, or notebook
* Cleaner chat filtering and rendering logic

---

**Breaking Changes**: None
**Migration Required**: Yes – run `alembic upgrade head`
**Frontend Impact**: Optional, but enables new context-aware capabilities

Let me know if you want a condensed version for a changelog or GitHub comment!Here is a structured Pull Request description following your specified format, tailored to the provided diff:

---

# 🧩 Add `page_id` Support to Conversations and Page Context Awareness

## Overview

This PR introduces native support for associating conversations with specific pages via a new `page_id` field in the `conversations` table. It also enhances both backend and frontend APIs to allow filtering, creation, and tracking of conversations by page, enabling better scoping of AI interactions within multi-page applications.

Additionally, the frontend now includes a global Page Context Service for consistent awareness of the current page's metadata throughout the app.

---

## 🎯 Key Features

### Conversation Page Association

* ✅ New database field: `page_id` added to the `conversations` table
* ✅ API support for filtering conversations by `page_id`
* ✅ Support for passing `page_id` in `ChatCompletionRequest` and `TextGenerationRequest`
* ✅ Alembic migration included with indexing for performance

### Page Context Tracking (Frontend)

* ✅ Introduced `PageContextService` to maintain and propagate `pageId`, `pageName`, and `isStudioPage` flags
* ✅ `DynamicPageRenderer` now sets global page context when a page loads
* ✅ Backend-ready foundation for page-scoped analytics, behavior, and personalization

---

## 📁 Files Added

### Migrations

* [`[add_page_id_to_conversations.py](https://chatgpt.com/c/backend/migrations/versions/add_page_id_to_conversations.py)`](backend/migrations/versions/add_page_id_to_conversations.py) – Adds `page_id` column and indexes
* [`[c7eed881f009_merge_heads.py](https://chatgpt.com/c/backend/migrations/versions/c7eed881f009_merge_heads.py)`](backend/migrations/versions/c7eed881f009_merge_heads.py) – Merges concurrent migration branches

### Frontend Service

* [`[PageContextService.ts](https://chatgpt.com/c/frontend/src/services/PageContextService.ts)`](frontend/src/services/PageContextService.ts) – New service for managing and broadcasting page metadata context

---

## 📝 Files Modified

### Backend Models & API

* `models/conversation.py`

  * Added `page_id` column and related query methods:

    * `get_by_user_id_and_page()`
    * `count_by_user_and_page()`
* `endpoints/conversations.py`

  * Added support for filtering and setting `page_id` in `GET`, `POST`, and `PUT` operations
* `endpoints/ai_providers.py`

  * Accepts and stores `page_id` in `chat_completion`
* `schemas/ai_providers.py`

  * Updated `ChatCompletionRequest` and `TextGenerationRequest` schemas to include `page_id` and `page_context`
* `schemas/conversation_schemas.py`

  * Added `page_id` field to `ConversationBase`

### Frontend Application

* `App.tsx`

  * Registered `pageContextService` with the service registry
* `DynamicPageRenderer.tsx`

  * Sets page context based on resolved route
  * Logs updates and reflects `pageId` changes
* `PluginManager` and other plugins can now subscribe to page context globally

---

## 🔧 Configuration

No new environment variables or external configuration is required. The system works automatically once the frontend page is resolved.

---

## 🚀 Usage

### Creating Conversations Associated with a Page

```json
POST /api/v1/conversations
{
  "title": "Page-Specific Conversation",
  "page_id": "page_abc123",
  "model": "gpt-4",
  "conversation_type": "chat"
}
```

### Filtering by Page

```
GET /api/v1/conversations?page_id=page_abc123
```

---

## 🔄 Migration Strategy

```bash
alembic upgrade head
```

### Migration Details

* Adds nullable `page_id` column to `conversations`
* Adds indexes:

  * `conversations.page_id`
  * `conversations.user_id + page_id`
* Existing conversations default to `page_id = NULL` (global scope)

---

## 🎯 Impact

### Developer Benefits

* Backend support for scoped conversations per page
* Enables modular dashboards with local chat history
* Simplifies tracking conversation flow and context per page

### Frontend Benefits

* Global `PageContextService` opens cross-component awareness of current page identity and behavior
* Foundation for per-page plugin behavior, analytics, or access control

---

## ⚠️ Important Notes

* This is a non-breaking schema expansion
* Migration is forward-only but safe
* Frontend plugin developers can now access current page ID and route from anywhere using `pageContextService.getCurrentPageContext()`

---

## 🔗 Related Use Cases

* Personal chat history per app section or workspace
* AI responses scoped to a specific studio, dashboard, or notebook
* Cleaner chat filtering and rendering logic

---

**Breaking Changes**: None
**Migration Required**: Yes – run `alembic upgrade head`
**Frontend Impact**: Optional, but enables new context-aware capabilities